### PR TITLE
Expand list of filtered meta functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The list of filtered functions in `.meta.wasm` expanded according to the new meta functions.
 
 ## [0.0.3]
 ### Added

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -64,11 +64,18 @@ impl BuildCommand {
         let mut module = parity_wasm::deserialize_file(&info.output_wasm)
             .context("unable to read the output WASM")?;
         let exports = vec![
+            "meta_async_handle_input",
+            "meta_async_handle_output",
+            "meta_async_init_input",
+            "meta_async_init_output",
+            "meta_handle_input",
+            "meta_handle_output",
             "meta_init_input",
             "meta_init_output",
-            "meta_input",
-            "meta_output",
             "meta_registry",
+            "meta_state",
+            "meta_state_input",
+            "meta_state_output",
             "meta_title",
         ];
         pwasm_utils::optimize(&mut module, exports)


### PR DESCRIPTION
- Add new functions to the filtering list when generating `.meta.wasm`.

